### PR TITLE
Update OpenTelemetryEcto attributes to conform with semantic conventions 1.27

### DIFF
--- a/instrumentation/opentelemetry_ecto/CHANGELOG.md
+++ b/instrumentation/opentelemetry_ecto/CHANGELOG.md
@@ -6,4 +6,33 @@ Forked from [`:opentelemetry_ecto` `1.2.0`](https://github.com/open-telemetry/op
 
 ### Changed
 
-- Initial release
+- Conforms to semantic conventions 1.27
+- Changed span name from `ecto.repo.query` to `{db.operation.name} {target}` / `{target}`
+
+### Adds
+
+- Added `db.namespace` attribute
+- Added `db.collection.name` attribute
+- Added `db.query.text` attribute
+- Added `server.address` attribute
+- Added `server.port` attribute
+- Added `db.client.operation.duration` (seconds in float)
+- Added `db.client.connection.wait_time` (seconds in float)
+- Added `db.client.connection.use_time` (seconds in float)
+- Added `:db_statement` config option
+
+### Removes
+
+- Removed `db.type` attribute
+- Removed `db.name` and `db.instance` attributes in favor of `db.namespace`
+- Removed `source` attribute in favor of `db.collection.name`
+- Removed `db.statement` attribute in favor of `db.query.text`
+- Removed `db.url` attirbute in favor of `server.address`/`server.port` attributes
+- Removed `total_time_*` attributes in favor `db.client.operation.duration`
+- Removed `idle_time_*` attributes in favor `db.client.operation.duration`
+- Removed `queue_time_*` attributes in favor of `db.client.connection.wait_time`
+- Removed `query_time_*` attributes in favor of `db.client.connection.use_time`
+- Removed `decode_time_*` attributes
+- Removed `:db_statement` config option in favor of `:db_query`
+- Removed `:span_prefix` config option
+- Removed `:time_unit` config option


### PR DESCRIPTION
Ported from https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/430

---


This conforms the attributes and span names to the 1.27 docs: https://github.com/open-telemetry/semantic-conventions/blob/v1.27.0/docs/database/database-spans.md

It does introduce a bunch of breaking changes so let me know if backwards compability is required. I can keep the old attributes, but not sure if we should just go with major release instead since there's a lot of things that are different now?

I can also update the changelog in this PR.

## Changes

- `db.name`/`db.instance` -> `db.namespace`
- `source` -> `db.collection.name`
- `db.statement` -> `db.query.text`
- `db.url` -> `server.address`/ `server.port`
- `total_time_` -> `db.client.operation.duration` (in seconds as float)
- `idle_time_` -> `db.client.connection.create_time` (in seconds as float)
- `queue_time_` -> `db.client.connection.wait_time` (in seconds as float)
- `query_time_` -> `db.client.connection.use_time` (in seconds as float)
- The `: db_statement` config option to `:db_query` (not necessary but it conforms closer to the otel attribute name)
- Span name changed from `ecto.repo.query` to `{db.operation.name} {target}` or just `{target}` if it is a general db operation conforming to 1.27 guidelines

## Removes
- `db.type`
- `decode_time_` (I couldn't find a metric that matched it)
- The `:span_prefix` config option
- The `:time_unit` config option

## Adds
- `db.operation.name`
