### PR TITLE
Update span names for OpentelemetryPhoenix

### DIFF
--- a/instrumentation/opentelemetry_phoenix/CHANGELOG.md
+++ b/instrumentation/opentelemetry_phoenix/CHANGELOG.md
@@ -7,3 +7,6 @@ Forked from [`:opentelemetry_phoenix` `2.0.1`](https://github.com/open-telemetry
 ### Changed
 
 - Added `http.route` attribute for LiveView spans
+- LiveView mount span name changed from `{live_view_module}.mount` to `live_view.mount {route}`
+- LiveView handle_params span name for LiveView spans changed from `{live_view_module}.handle_params` to `live_view.handle_params {route}`
+- LiveView handle_event span name changed from `{live_view_module}.handle_event {event}` to `live_view.handle_event {route} {event}`

--- a/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
+++ b/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
@@ -166,11 +166,14 @@ defmodule OpentelemetryPhoenix do
         %{socket: %{view: live_view}} = meta,
         _handler_configuration
       ) do
+    start_opts = live_view_start_opts(meta)
+    target = target(start_opts.attributes, live_view)
+
     OpentelemetryTelemetry.start_telemetry_span(
       @tracer_id,
-      "#{inspect(live_view)}.mount",
+      "live_view.mount #{target}",
       meta,
-      live_view_start_opts(meta)
+      start_opts
     )
   end
 
@@ -180,11 +183,14 @@ defmodule OpentelemetryPhoenix do
         %{socket: %{view: live_view}} = meta,
         _handler_configuration
       ) do
+    start_opts = live_view_start_opts(meta)
+    target = target(start_opts.attributes, live_view)
+
     OpentelemetryTelemetry.start_telemetry_span(
       @tracer_id,
-      "#{inspect(live_view)}.handle_params",
+      "live_view.handle_params #{target}",
       meta,
-      live_view_start_opts(meta)
+      start_opts
     )
   end
 
@@ -194,9 +200,12 @@ defmodule OpentelemetryPhoenix do
         %{socket: %{view: live_view}, event: event} = meta,
         _handler_configuration
       ) do
+    start_opts = live_view_start_opts(meta)
+    target = target(start_opts.attributes, live_view)
+
     OpentelemetryTelemetry.start_telemetry_span(
       @tracer_id,
-      "#{inspect(live_view)}.handle_event##{event}",
+      "live_view.handle_event #{target} #{event}",
       meta,
       live_view_start_opts(meta)
     )
@@ -243,4 +252,8 @@ defmodule OpentelemetryPhoenix do
   end
 
   defp url_attributes(_meta), do: %{}
+
+  defp target(attributes, live_view) do
+    attributes[HTTPAttributes.http_route()] || inspect(live_view)
+  end
 end

--- a/instrumentation/opentelemetry_phoenix/test/opentelemetry_phoenix_test.exs
+++ b/instrumentation/opentelemetry_phoenix/test/opentelemetry_phoenix_test.exs
@@ -119,7 +119,7 @@ defmodule OpentelemetryPhoenixTest do
 
     assert_receive {:span,
                     span(
-                      name: "NnnnnWeb.ResourceLive.Show.mount",
+                      name: "live_view.mount /resources/:resource_id",
                       attributes: attributes
                     )}
 
@@ -143,7 +143,7 @@ defmodule OpentelemetryPhoenixTest do
 
     assert_receive {:span,
                     span(
-                      name: "NnnnnWeb.ResourceLive.Show.handle_params",
+                      name: "live_view.handle_params /resources/:resource_id",
                       attributes: attributes
                     )}
 
@@ -167,7 +167,7 @@ defmodule OpentelemetryPhoenixTest do
 
     assert_receive {:span,
                     span(
-                      name: "NnnnnWeb.ResourceLive.Show.handle_event#hello",
+                      name: "live_view.handle_event /resources/:resource_id hello",
                       attributes: attributes
                     )}
 
@@ -203,7 +203,7 @@ defmodule OpentelemetryPhoenixTest do
 
     assert_receive {:span,
                     span(
-                      name: "NnnnnWeb.ResourceLive.Show.mount",
+                      name: "live_view.mount /resources/:resource_id",
                       attributes: attributes
                     )}
 
@@ -211,7 +211,7 @@ defmodule OpentelemetryPhoenixTest do
 
     assert_receive {:span,
                     span(
-                      name: "NnnnnWeb.ResourceLive.Show.handle_params",
+                      name: "live_view.handle_params /resources/:resource_id",
                       attributes: attributes,
                       events: events
                     )}
@@ -250,7 +250,7 @@ defmodule OpentelemetryPhoenixTest do
 
     assert_receive {:span,
                     span(
-                      name: "NnnnnWeb.ResourceLive.Show.handle_event#hello",
+                      name: "live_view.handle_event /resources/:resource_id hello",
                       attributes: attributes,
                       events: events
                     )}


### PR DESCRIPTION
Ported from: https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/433

Stacked on top of #2 

---

I don't see any convention for how span names should be handled for websocket events other than maybe using the messaging namespace, but I think we want the structure to be more in line with how span names usually look: `{operation} {resource}`

So instead of `MyAppWeb.ResourceLive.Show.mount` it becomes `live_view.mount /resources/:resource_id` (for events it'll be `live_view.handle_event /resources/:resource_id hello`.

This is a breaking change.

## Changes

- Span names changed from `{live_view_module}.{handler_function}` to `live_view.{handler_function} {route}`
- Span names changed from `{live_view_module}.handle_event {event}` to `live_view.handle_event {route} {event}`