### PR TITLE
Remove deprecated warnings_as_errors compile opt for OpentelemetryPhoenix

### DIFF
--- a/instrumentation/opentelemetry_phoenix/test/test_helper.exs
+++ b/instrumentation/opentelemetry_phoenix/test/test_helper.exs
@@ -1,2 +1,1 @@
 ExUnit.start()
-Code.put_compiler_option(:warnings_as_errors, true)


### PR DESCRIPTION
Port from https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/447

---

The CI already runs `mix compile --warnings-as-errors` so it's not necessary to set this option. It'll remove this warning when running the test:

```
warning: :warnings_as_errors is deprecated as part of Code.put_compiler_option/2, instead you must pass it as a --warnings-as-errors flag. If you need to set it as a default in a mix task, you can also set it under aliases: [compile: "compile --warnings-as-errors"]
  (elixir 1.18.1) lib/code.ex:1710: Code.put_compiler_option/2
  test/test_helper.exs:2: (file)
  (elixir 1.18.1) src/elixir_compiler.erl:77: :elixir_compiler.dispatch/4
  (elixir 1.18.1) src/elixir_compiler.erl:52: :elixir_compiler.compile/4
  (elixir 1.18.1) src/elixir_compiler.erl:39: :elixir_compiler.maybe_fast_compile/2
  (elixir 1.18.1) src/elixir_lexical.erl:13: :elixir_lexical.run/3
```